### PR TITLE
Remove a YAML separator of the top of output

### DIFF
--- a/ksort.go
+++ b/ksort.go
@@ -168,16 +168,19 @@ func (o *options) run(out io.Writer) error {
 	}
 	glog.V(2).Infof("Found %d objects in total", len(manifests))
 
-	for _, m := range tiller.SortByKind(manifests) {
-		fmt.Fprintf(out, "---\n# Source: %s\n", m.Name)
+	a := make([]string, len(manifests))
+	for i, m := range tiller.SortByKind(manifests) {
+		a[i] += fmt.Sprintf("# Source: %s\n", m.Name)
 
 		if m.Head.Kind == kindUnknown {
-			fmt.Fprintln(out, "# WARNING: It looks like that this file is not a manifest file")
+			a[i] += "# WARNING: It looks like that this file is not a manifest file\n"
 			continue
 		}
 
-		fmt.Fprintln(out, m.Content)
+		a[i] += m.Content
 	}
+
+	fmt.Fprintln(out, strings.Join(a, "\n---\n"))
 
 	return nil
 }

--- a/ksort_test.go
+++ b/ksort_test.go
@@ -13,8 +13,7 @@ func TestCommand(t *testing.T) {
 	}{
 		{
 			args: []string{"testdata/rbac.yaml"},
-			out: `---
-# Source: testdata/rbac.yaml
+			out: `# Source: testdata/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -41,8 +40,7 @@ metadata:
 		},
 		{
 			args: []string{"testdata"},
-			out: `---
-# Source: testdata/configmap.yaml
+			out: `# Source: testdata/configmap.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
I prefer that  a YAML separator of the top of manifest file doesn't exist.

```yaml
--- # <--- REMOVE
# Source: testdata/configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: configmap
---
# Source: testdata/rbac.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: ClusterRole
```