### PR TITLE
Add --delete flag that sorts manifests in uninstall order

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To pass the result into the stdin of `kubectl apply` command is also convenient.
 $ ksort ./manifests | kubectl apply -f -
 ```
 
-Sort the manifests contained the manifest file that is specified.
+Sort manifests contained the manifest file that is specified.
 ```
 $ ksort ./app.yaml
 ```

--- a/ksort_test.go
+++ b/ksort_test.go
@@ -110,6 +110,39 @@ metadata:
   name: deployment
 `,
 		},
+		{
+			args: []string{"testdata/deployment.yaml", "testdata/rbac.yaml", "--delete"},
+			out: `# Source: testdata/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment
+---
+# Source: testdata/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: RoleBinding
+---
+# Source: testdata/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: Role
+---
+# Source: testdata/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ClusterRoleBinding
+---
+# Source: testdata/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ClusterRole
+`,
+		},
 	}
 
 	for i, tt := range tests {


### PR DESCRIPTION
```
# Sort manifests in uninstall order.
$ ksort ./manifests --delete
```