### PR TITLE
Fix to pass GOOS and GOARCH into a build container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,16 @@ GOOS ?= $(shell uname | tr A-Z a-z)
 GOARCH ?= amd64
 GOCACHE ?= $(shell pwd)/.go-build
 GO_WORKDIR := /go/src/$(REPO_PATH)
-GO ?= docker run --rm -e GOOS -e GOARCH -e CGO_ENABLED=0 -w $(GO_WORKDIR) -v $(shell pwd):$(GO_WORKDIR) -v $(GOCACHE):/root/.cache/go-build golang:$(GO_VERSION) go
+GO ?= docker run \
+    --rm \
+    -e GOOS=$(GOOS) \
+    -e GOARCH=$(GOARCH) \
+    -e CGO_ENABLED=0 \
+    -w $(GO_WORKDIR) \
+    -v $(shell pwd):$(GO_WORKDIR) \
+    -v $(GOCACHE):/root/.cache/go-build \
+    golang:$(GO_VERSION) \
+    go
 OUT_DIR ?= _output
 LDFLAGS :=
 LDFLAGS += -X $(REPO_PATH).GitCommit=$(GIT_COMMIT)


### PR DESCRIPTION
This PR fixes to be able to build for other than Linux such as macos.