### PR TITLE
Improve UX by using `-f` and `-R` flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,18 +17,18 @@ Sort manifest files in the `deploy` directory in the proper order, and output th
 ```
 $ ls ./manifests
 deployment.yaml  ingress.yaml  namespace.yaml  service.yaml
-$ ksort ./manifests
+$ ksort -f ./manifests
 ```
 
 To pass the result into the stdin of `kubectl apply` command is also convenient.
 
 ```
-$ ksort ./manifests | kubectl apply -f -
+$ ksort -f ./manifests | kubectl apply -f -
 ```
 
 Sort manifests contained the manifest file that is specified.
 ```
-$ ksort ./app.yaml
+$ ksort -f ./app.yaml
 ```
 
 ## Installation

--- a/cmd/ksort/main.go
+++ b/cmd/ksort/main.go
@@ -8,13 +8,20 @@ file that was distributed with this source code.
 package main
 
 import (
+	"flag"
 	"os"
 
 	"github.com/superbrothers/ksort"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
+func init() {
+	flag.Set("logtostderr", "true")
+}
+
 func main() {
-	cmd := ksort.NewCommand(os.Stdin, os.Stdout, os.Stderr)
+	streams := genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}
+	cmd := ksort.NewCommand(streams)
 	if err := cmd.Execute(); err != nil {
 		os.Exit(1)
 	}

--- a/go.mod
+++ b/go.mod
@@ -51,12 +51,12 @@ require (
 	gopkg.in/square/go-jose.v2 v2.3.1 // indirect
 	k8s.io/apiextensions-apiserver v0.0.0-20190426053235-842c4571cde0 // indirect
 	k8s.io/apiserver v0.0.0-20190426133039-accf7b6d6716 // indirect
-	k8s.io/cli-runtime v0.0.0-20190425173743-daa7a1d0e123 // indirect
+	k8s.io/cli-runtime v0.0.0-20190425173743-daa7a1d0e123
 	k8s.io/cloud-provider v0.0.0-20190425174118-0a4f4cbb5a66 // indirect
 	k8s.io/helm v2.13.1+incompatible
 	k8s.io/klog v0.3.0
 	k8s.io/kube-openapi v0.0.0-20190426233423-c5d3b0f4bee0 // indirect
-	k8s.io/kubernetes v0.0.0-00010101000000-000000000000 // indirect
+	k8s.io/kubernetes v0.0.0-00010101000000-000000000000
 	k8s.io/utils v0.0.0-20190308190857-21c4ce38f2a7 // indirect
 	sigs.k8s.io/kustomize v2.0.3+incompatible // indirect
 	sigs.k8s.io/yaml v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -210,8 +210,10 @@ github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR
 github.com/philhofer/fwd v1.0.0/go.mod h1:gk3iGcWd9+svBvR0sR+KPcfE+RNWozjowpeBVG3ZVNU=
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021/go.mod h1:prYjPmNq4d1NPVmpShWobRqXY3q7Vp+80DqgxxUrUIA=
 github.com/pquerna/ffjson v0.0.0-20180717144149-af8b230fcd20/go.mod h1:YARuvh7BUWHNhzDq2OM5tzR2RiCcN2D7sapiKyCel/M=
@@ -241,6 +243,7 @@ github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnIn
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v0.0.0-20151208002404-e3a8ff8ce365/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/technosophos/moniker v0.0.0-20180509230615-a5dbd03a2245 h1:DNVk+NIkGS0RbLkjQOLCJb/759yfCysThkMbl7EXxyY=
 github.com/technosophos/moniker v0.0.0-20180509230615-a5dbd03a2245/go.mod h1:O1c8HleITsZqzNZDjSNzirUGsMT0oGu9LhHKoJrqO+A=

--- a/testdata/test-recursive/ns.yaml
+++ b/testdata/test-recursive/ns.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-recursive


### PR DESCRIPTION
This PR changes to use `-f` and `-R` flags instead arguments in order to specify filename or directory so that it feels like `kubectl`. With this change, specifing file names with arguments is obsoleted.

/fix #20 