### PR TITLE
Fix to print version information with version flag

### DIFF
--- a/ksort.go
+++ b/ksort.go
@@ -25,10 +25,6 @@ import (
 	"k8s.io/klog"
 )
 
-var (
-	printVersion = false
-)
-
 const (
 	ksortLong = `When installing manifests, they should be sorted in a proper order by Kind.
 For example, Namespace object must be in the first place when installing them.
@@ -79,6 +75,8 @@ func newOptions(streams genericclioptions.IOStreams) *options {
 func NewCommand(streams genericclioptions.IOStreams) *cobra.Command {
 	o := newOptions(streams)
 
+	printVersion := false
+
 	cmd := &cobra.Command{
 		Use:     "ksort -f FILENAME",
 		Short:   "ksort sorts manfest files in a proper order by Kind.",
@@ -105,7 +103,6 @@ func NewCommand(streams genericclioptions.IOStreams) *cobra.Command {
 	}
 
 	o.filenameFlags.AddFlags(cmd.Flags())
-	cmd.MarkFlagRequired("filename")
 	cmd.Flags().BoolVarP(&o.delete, "delete", "d", o.delete, "Sort manifests in uninstall order")
 	cmd.Flags().BoolVar(&printVersion, "version", printVersion, "Print the version and exit")
 	cmd.Flags().AddGoFlagSet(flag.CommandLine)

--- a/ksort_test.go
+++ b/ksort_test.go
@@ -1,10 +1,25 @@
 package ksort
 
 import (
+	"strings"
 	"testing"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
+
+func TestPrintVersionInformation(t *testing.T) {
+	streams, _, _, errOut := genericclioptions.NewTestIOStreams()
+	cmd := NewCommand(streams)
+	cmd.SetArgs([]string{"--version"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Errorf("cmd.Execute() => %q", err)
+	}
+
+	if !strings.Contains(errOut.String(), "&ksort.info{") {
+		t.Errorf("expect to include version information, but got %q", errOut)
+	}
+}
 
 func TestCommand(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
Due to the change of #22, `--version` flag has not worked correctly. This PR fixes that.