### PR TITLE
Stdin support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ Sort manifests contained the manifest file that is specified.
 $ ksort -f ./app.yaml
 ```
 
+Sort manifests passed into stdin.
+```
+$ cat app.yaml | ksort -f-
+```
+
 ## Installation
 
 You can download an archive file from [GitHub Releases](https://github.com/superbrothers/ksort/releases), then extract it and install a binary.

--- a/ksort_test.go
+++ b/ksort_test.go
@@ -24,10 +24,12 @@ func TestPrintVersionInformation(t *testing.T) {
 func TestCommand(t *testing.T) {
 	tests := []struct {
 		args []string
+		in   string
 		out  string
 	}{
 		{
 			args: []string{"--filename", "testdata/rbac.yaml"},
+			in:   "",
 			out: `# Source: testdata/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -55,6 +57,7 @@ metadata:
 		},
 		{
 			args: []string{"--filename", "testdata"},
+			in:   "",
 			out: `# Source: testdata/configmap.yaml
 apiVersion: v1
 kind: ConfigMap
@@ -94,6 +97,7 @@ metadata:
 		},
 		{
 			args: []string{"--filename", "testdata/deployment.yaml", "--filename", "testdata/rbac.yaml"},
+			in:   "",
 			out: `# Source: testdata/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -160,6 +164,7 @@ metadata:
 		},
 		{
 			args: []string{"--recursive", "--filename", "testdata"},
+			in:   "",
 			out: `# Source: testdata/test-recursive/ns.yaml
 apiVersion: v1
 kind: Namespace
@@ -203,10 +208,34 @@ metadata:
   name: deployment
 `,
 		},
+		{
+			args: []string{"--filename", "-"},
+			in: `apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ClusterRoleBinding
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ClusterRole
+`,
+			out: `apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ClusterRole
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ClusterRoleBinding
+`,
+		},
 	}
 
 	for i, tt := range tests {
-		streams, _, out, _ := genericclioptions.NewTestIOStreams()
+		streams, in, out, _ := genericclioptions.NewTestIOStreams()
+		in.WriteString(tt.in)
 		cmd := NewCommand(streams)
 		cmd.SetArgs(tt.args)
 

--- a/testdata/configmap.yaml
+++ b/testdata/configmap.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/testdata/deployment.yaml
+++ b/testdata/deployment.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
With this PR, ksort allows you to sort manifests passed into stdin.

```
$ cat app.yaml | ksort -f-
```

/closes #29 