### PR TITLE
Add LICENSE.txt file into archives

### DIFF
--- a/hack/sort-manifests.yaml
+++ b/hack/sort-manifests.yaml
@@ -20,6 +20,8 @@ spec:
     files:
     - from: ksort
       to: .
+    - from: LICENSE.txt
+      to: .
     selector:
       matchLabels:
         os: darwin
@@ -29,6 +31,8 @@ spec:
     bin: ksort
     files:
     - from: ksort
+      to: .
+    - from: LICENSE.txt
       to: .
     selector:
       matchLabels:


### PR DESCRIPTION
Archive files distributed as Krew package have to be included License file.