### PR TITLE
Publish archive files in tar.gz format

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ deploy:
   file:
   - "out/*.zip"
   - "out/*.zip.sha256"
+  - "out/*.tar.gz"
+  - "out/*.tar.gz.sha256"
   - "out/sort-manifests.yaml"
   skip_cleanup: true
   on:

--- a/hack/make-archives.sh
+++ b/hack/make-archives.sh
@@ -13,21 +13,27 @@ if [[ ! -d "${bin_dir}" ]]; then
     exit 1
 fi
 
+# Create archive files in zip and tar.gz format for each arch
 for osarch in $(ls "$bin_dir"); do
-  archive_file="out/ksort-${osarch}.zip"
-  echo "Creating ${archive_file}" >&2
-  ( \
-    cd "${bin_dir}/${osarch}/" && \
-    cp ../../../LICENSE.txt . && \
-    cp ../../../README.md . && \
-    zip -r "../../../${archive_file}" * \
-  )
+  for format in zip tar.gz; do
+    archive_file="out/ksort-${osarch}.${format}"
+    echo "Creating ${archive_file}" >&2
+    ( \
+      cd "${bin_dir}/${osarch}/" && \
+      cp ../../../LICENSE.txt . && \
+      cp ../../../README.md . && \
+      [[ "$format" == "zip" ]] && \
+        zip -r "../../../${archive_file}" * \
+      || \
+        tar zcvf "../../../${archive_file}" * \
+    )
 
-  tar_sumfile="${archive_file}.sha256"
-  tar_checksum="$(shasum -a 256 "$archive_file" | awk '{print $1}')"
-  echo "${archive_file}: checksum: ${tar_checksum}" >&2
-  echo "$tar_checksum" >"${tar_sumfile}"
-  echo "Written ${tar_sumfile}"
+    archive_sumfile="${archive_file}.sha256"
+    archive_checksum="$(shasum -a 256 "$archive_file" | awk '{print $1}')"
+    echo "${archive_file}: checksum: ${archive_checksum}" >&2
+    echo "$archive_checksum" >"${archive_sumfile}"
+    echo "Written ${archive_sumfile}"
+  done
 done
 
 # Copy and process ksort manifest


### PR DESCRIPTION
With this PR, archive files in `tar.gz` format are also published in addition to `zip` format.

Closes #32 